### PR TITLE
fix: footer logos visibility in light theme.

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -196,16 +196,26 @@ body {
   margin: 0;
   font-family: var(--font-family-base);
   color: var(--text-body);
-  background:
-    radial-gradient(900px 520px at 85% 8%, var(--bg-orb-1), transparent 70%),
+  background: radial-gradient(
+      900px 520px at 85% 8%,
+      var(--bg-orb-1),
+      transparent 70%
+    ),
     radial-gradient(800px 420px at 10% 70%, var(--bg-orb-2), transparent 72%),
-    linear-gradient(180deg, var(--bg-base-1) 0%, var(--bg-base-2) 48%, var(--bg-base-2) 100%);
+    linear-gradient(
+      180deg,
+      var(--bg-base-1) 0%,
+      var(--bg-base-2) 48%,
+      var(--bg-base-2) 100%
+    );
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  color: inherit;
+@layer base {
+  a {
+    color: inherit;
+  }
 }
 
 .section-heading {
@@ -230,7 +240,8 @@ a {
   border: 2px solid transparent;
   text-decoration: none;
   cursor: pointer;
-  transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+  transition: background-color 0.25s ease, color 0.25s ease,
+    border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
 .btn-ui:focus-visible {
@@ -248,7 +259,8 @@ a {
 .btn-ui-primary {
   background: var(--btn-primary-bg);
   color: var(--btn-primary-text);
-  box-shadow: 0 6px 18px color-mix(in srgb, var(--btn-primary-bg) 35%, transparent);
+  box-shadow: 0 6px 18px
+    color-mix(in srgb, var(--btn-primary-bg) 35%, transparent);
 }
 
 .btn-ui-primary:hover {
@@ -288,8 +300,14 @@ a {
 
 .btn-ui-view-tracks:hover {
   background: var(--btn-view-tracks-hover-bg, var(--btn-secondary-hover-bg));
-  border-color: var(--btn-view-tracks-hover-border, var(--btn-secondary-hover-border));
-  color: var(--btn-view-tracks-hover-text, var(--btn-view-tracks-text, var(--btn-secondary-text)));
+  border-color: var(
+    --btn-view-tracks-hover-border,
+    var(--btn-secondary-hover-border)
+  );
+  color: var(
+    --btn-view-tracks-hover-text,
+    var(--btn-view-tracks-text, var(--btn-secondary-text))
+  );
 }
 
 html.dark {
@@ -398,6 +416,3 @@ html.dark .roadmap-card-eval-title {
 html.dark .roadmap-card-eval-item {
   color: var(--text-muted);
 }
-
-
-


### PR DESCRIPTION
## Summary 🧾

Describe what this PR changes and why.
The social logos were not visible on hover in light mode, the anchor tag in the global.css a {color:inherit} was taking the highest priority over all other hover so put it in @layer-base to let the user defined styles in the footer.jsx take on properly.

## Linked Issue 🔗
https://github.com/QuCodeXClub/Q-hackathon/issues/26
Closes #26

## Type of Change 🛠️

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Screenshots (if UI) 🖼️
<img width="253" height="99" alt="Screenshot 2026-04-18 at 2 33 58 AM" src="https://github.com/user-attachments/assets/1e0a310e-e0be-4ad9-9a90-5d880b21632d" />
<img width="210" height="107" alt="Screenshot 2026-04-18 at 2 25 50 AM" src="https://github.com/user-attachments/assets/9b669e8e-ff5d-4007-b4eb-b44e9ae8f5fd" />



Add before/after images or a short video.

## Testing 🧪

- [x] `npm run build` passes locally
- [x] Manual verification completed
- [x] Edge cases reviewed

## PR Rules Checklist ✅

- [ ] PR is focused and small
- [x] No unrelated formatting changes
- [ ] Docs updated if behavior changed
- [x] Ready for review
