### PR TITLE
fix: add CodeChef Pro perk and fix domain eligibility wording 

### DIFF
--- a/src/components/prizes.jsx
+++ b/src/components/prizes.jsx
@@ -41,8 +41,14 @@ const generalPerks = [
   {
     Icon: Globe,
     title: "1-Year .xyz Domain",
-    desc: "Worth ₹1L+ for all participants",
+    desc: "Worth ₹1L+ for selected participants",
     color: "#3b82f6"
+  },
+  {
+    Icon: Star,
+    title: "Three CodeChef Pro Subscriptions",
+    desc: "One each to a selected student from each of the top 3 teams",
+    color: "#10b981"
   },
   {
     Icon: Gift,


### PR DESCRIPTION
## Summary
Added missing CodeChef Pro perk to the Prizes section and corrected 
inaccurate eligibility wording for the .xyz domain perk.

## Linked Issue
Closes #42

## Type of Change
- [ ] Bug Fix
- [x] Content Update

## Changes Made
- Added new perk: Three CodeChef Pro account subscriptions — one each 
  to a selected student from each of the top 3 teams
- Fixed domain perk wording from "for all participants" to 
  "for selected participants" to accurately reflect limited eligibility

## Testing
- [ ] `npm run build` passes locally
- [ ] Visual check done on Prizes section