### PR TITLE
fix: correct card alignment and spacing in Perks for Everyone

### DIFF
--- a/src/components/prizes.jsx
+++ b/src/components/prizes.jsx
@@ -201,7 +201,7 @@ const Prizes = () => {
             Perks for Everyone
           </h3>
           
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 sm:gap-10">
             {generalPerks.map((perk, i) => (
               <motion.div 
                 key={perk.title}

--- a/src/components/prizes.jsx
+++ b/src/components/prizes.jsx
@@ -95,7 +95,7 @@ const PrizeCard = ({ tier, Icon, label, amount, perks, accentColor, bgGradient, 
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-50px" }}
       transition={{ duration: 0.7, delay: index * 0.15, ease: "easeOut" }}
-      className={`w-full max-w-sm mx-auto flex ${desktopOrder}`}
+      className={`w-full max-w-sm mx-auto flex ${desktopOrder} relative z-10`}
       style={{ perspective: 1000, willChange: "transform", zIndex: isGold ? 20 : 10 }}
       onMouseMove={handleMouseMove}
       onMouseLeave={() => { x.set(0); y.set(0); }}
@@ -186,7 +186,7 @@ const Prizes = () => {
             <span className="text-xl sm:text-2xl font-black text-(--primary)">₹1,50,000+ Worth</span>
           </div>
         </motion.div>
-        <div className="flex flex-col md:flex-row items-center md:items-end justify-center gap-6 md:gap-4 lg:gap-8 mb-24">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-4 lg:gap-8 mb-24 relative z-10 justify-items-center">
           {prizes.map((prize, i) => (
             <PrizeCard key={prize.tier} {...prize} index={i} />
           ))}
@@ -201,7 +201,7 @@ const Prizes = () => {
             Perks for Everyone
           </h3>
           
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 sm:gap-10">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-8 sm:gap-10 relative z-10">
             {generalPerks.map((perk, i) => (
               <motion.div 
                 key={perk.title}
@@ -209,7 +209,7 @@ const Prizes = () => {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ duration: 0.5, delay: 0.3 + (i * 0.1) }}
-                className="flex flex-col items-center text-center p-6 rounded-2xl border border-(--border-soft) bg-(--bg-card-dark) backdrop-blur-md shadow-sm hover:bg-(--bg-card-dark) hover:shadow-md hover:-translate-y-1 transition-all duration-300"
+                className={`flex flex-col items-center text-center p-6 rounded-2xl border border-(--border-soft) bg-(--bg-card-dark) backdrop-blur-md shadow-sm hover:bg-(--bg-card-dark) hover:shadow-md hover:-translate-y-1 transition-all duration-300 lg:col-span-2 ${i === 3 ? 'lg:col-start-2' : ''}`}
               >
                 <div 
                   className="w-12 h-12 rounded-xl flex items-center justify-center mb-4"


### PR DESCRIPTION
## Summary
Fixed card alignment, spacing, and visual issues in the "Perks for Everyone" section.

## Linked Issue
Closes #47

## Type of Change
- [x] Bug Fix
- [x] UI Improvement

## Changes Made
- Changed grid layout from lg:grid-cols-4 to lg:grid-cols-3 for better balance
- Increased card gap from gap-4/sm:gap-6 to gap-8/sm:gap-10 for even spacing
- Bottom 2 cards centered using flex justify-center for inverted triangle layout
- Fixed z-index issue causing background blob to overlap cards
- Darkened description text to text-gray-700 for better readability without overpowering titles

## Screenshots
**Before:**
<img width="1873" height="736" alt="image" src="https://github.com/user-attachments/assets/8829034e-8f10-4a3a-9359-6db06de98550" />


**After:**
<img width="1858" height="720" alt="image" src="https://github.com/user-attachments/assets/20cad3e6-12ad-48e6-8709-d4c454407051" />